### PR TITLE
Fixing the dependencies problem that failed the CI testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,4 +187,5 @@ dist/
 .ipynb_checkpoints/
 .cache/
 running_checks.ipynb
+notebook_for_bash_commands.ipynb
 =*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "llm_router"                       # PyPI-normalized, keep lowercase
+name = "llm_router"                     
 version = "0.2.1"
 description = "The Python library that lets you spin up any LLM with a single function. Route between local and remote LLMs with a unified interface."
 readme = "README.md"
@@ -17,19 +17,19 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 
-[tool.setuptools.packages.find]
-where = ["src"]
-include = ["llm_router*"]
-
-[tool.setuptools.package-data]
-llm_router = ["py.typed"]
-
 dependencies = [
   "requests>=2.31.0",
   "psutil>=5.9.0",
   "langchain-core>=0.2.0",
   "langchain-ollama>=0.1.0",
 ]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["llm_router*"]
+
+[tool.setuptools.package-data]
+llm_router = ["py.typed"]
 
 [project.optional-dependencies]
 openai = ["langchain-openai>=0.2.0"]


### PR DESCRIPTION
Fixing the dependencies' location in the pyproject.toml file, is it was misplaced. Also updating .gitignore.

All tests check out, including black and ruff.
